### PR TITLE
Fix seleniumwire crash with pyOpenSSL >= 23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ chromedriver-autoinstaller==0.6.4
 selenium-wire==5.1.0
 blinker==1.7.0
 brotlipy==0.7.0
+pyOpenSSL==22.1.0


### PR DESCRIPTION
## Problem

GitHub Actions runners recently updated `pyOpenSSL` to a version >= 23.0, which removed the `get_extension` method from `X509` objects. This causes `selenium-wire`'s bundled `mitmproxy` to crash immediately on any ISSA symbol:

```
AttributeError: 'X509' object has no attribute 'get_extension'
  File ".../seleniumwire/thirdparty/mitmproxy/certs.py", line 494, in altnames
    ext = self.x509.get_extension(i)
```

## Fix

Pin `pyOpenSSL==22.1.0` in `requirements.txt`. This is the last version before the API break.

## Note

`selenium-wire` is unmaintained and unlikely to ship a proper fix. Pinning `pyOpenSSL` is the standard workaround used by others hitting this issue.